### PR TITLE
Never create a new plot when plot is false

### DIFF
--- a/R/ts_anom_detection.R
+++ b/R/ts_anom_detection.R
@@ -297,7 +297,11 @@ AnomalyDetectionTs <- function(x, max_anoms = 0.10, direction = 'pos',
   # If there are no anoms, then let's exit
   if(anom_pct == 0){
     if(verbose) message("No anomalies detected.")
-    return (list("anoms"=data.frame(), "plot"=plot.new()))
+    if(plot) {
+      return (list("anoms" = data.frame(), "plot" = plot.new()))
+    } else {
+      return (list("anoms" = data.frame(), "plot" = NULL))
+    }
   }
 
   if(plot){

--- a/R/vec_anom_detection.R
+++ b/R/vec_anom_detection.R
@@ -224,7 +224,11 @@ AnomalyDetectionVec = function(x, max_anoms=0.10, direction='pos',
   # If there are no anoms, then let's exit
   if(anom_pct == 0){
     if(verbose) message("No anomalies detected.")
-    return (list("anoms"=data.frame(), "plot"=plot.new()))
+    if(plot) {
+      return (list("anoms" = data.frame(), "plot" = plot.new()))
+    } else {
+      return (list("anoms" = data.frame(), "plot" = NULL))
+    }
   }
   
   if(plot){


### PR DESCRIPTION
I ran into an issue running in a headless rserve instance that was caused by plot.new() being called even when the plot parameter was set to false. This fixes that problem.